### PR TITLE
fix: bump `rive` to 0.10.0, remove unused `decorated_icon` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+##[2.2.0] - 18 April 2023
+
+* Bump `rive` to 0.10.0
+* Remove unused `decorated_icon` dependency
+
 ##[2.1.0] - 6 April 2023
 
 *  Made the Introscreen scaffold transparent so a custom background can be used.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  decorated_icon: ^1.2.0
-  rive: ">=0.7.28 <0.11.0"
+  rive: ^0.10.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Describe your changes

## Checklist before requesting a review
- [ ] Test coverage is adequate
- [ ] Test makes sense
- [ ] Code is documented(all public methods)
- [ ] Code quality is adequate
- [ ] Feature complete
- [ ] (Almost no bugs)
- [ ] Dart analyzer completes without failure
- [ ] Changelog is updated
- [ ] Version is updated
- [ ] Readme is clean
